### PR TITLE
CMake: Re-add old include parent directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -330,7 +330,7 @@ install(TARGETS Util EXPORT LibraryExport
 # Set include directories for users of this library
 target_include_directories(Util
                            INTERFACE
-                           "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>"
+                           "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>" "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>/.."
                            "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
 
 # Library export


### PR DESCRIPTION
This fixes the PADrend superbuild, where this library is checked out to a
directory called "Util".
In the long term, the cleanest solution would be to move the header files into
a directory that ends with Util (e.g., "include/Util").